### PR TITLE
Update extension_attributes

### DIFF
--- a/scripts/extension_attributes
+++ b/scripts/extension_attributes
@@ -76,7 +76,7 @@ class XmlDictConfig(dict):
         if list(parent_element.items()):
             self.update(dict(list(parent_element.items())))
         for element in parent_element:
-            if element:
+            if len(element):
                 # treat like dict - we assume that if the first two tags
                 # in a series are different, then they are all different.
                 if len(element) == 1 or element[0].tag != element[1].tag:
@@ -101,7 +101,7 @@ class XmlDictConfig(dict):
             # finally, if there are no child tags and no attributes, extract
             # the text
             else:
-                self.update({element.tag: element.text})   
+                self.update({element.tag: element.text})      
 
 def remove_all(substr, string):
     try:


### PR DESCRIPTION
Use if len(element): on line 79 to avoid deprecation warning: Error: /usr/local/munkireport/scripts/extension_attributes:79: DeprecationWarning: Testing an element's truth value will raise an exception in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
  if element: